### PR TITLE
internal: enable XattrPrivileged for untar to fix selinux issue

### DIFF
--- a/internal/torcx/perform.go
+++ b/internal/torcx/perform.go
@@ -328,6 +328,7 @@ func unpackTgz(applyCfg *ApplyConfig, tgzPath, imageName string) (string, error)
 
 	tr := tar.NewReader(gr)
 	untarCfg := pkgtar.ExtractCfg{}.Default()
+	untarCfg.XattrPrivileged = true
 	err = pkgtar.ChrootUntar(tr, topDir, untarCfg)
 	if err != nil {
 		return "", errors.Wrapf(err, "unpacking %q", tgzPath)


### PR DESCRIPTION
To be able to extract tarballs with selinux contexts, torcx needs to turn on `XattrPrivileged`, because the default `XattrUser` option is able to extract only selinux contexts starting with `user` prefix.

See also:
https://github.com/flatcar-linux/coreos-overlay/pull/55
https://github.com/flatcar-linux/scripts/pull/16