### PR TITLE
pkg/tar: ignore EOPNOTSUPP from return value of Setxattr for Edge

### DIFF
--- a/pkg/tar/untar.go
+++ b/pkg/tar/untar.go
@@ -195,7 +195,7 @@ func extractOne(hdr *tar.Header, r io.Reader, targetDir string, cfg ExtractCfg) 
 			}
 
 			err := unix.Setxattr(path, k, []byte(v), 0)
-			if err != nil {
+			if err != nil && err != unix.EOPNOTSUPP {
 				return err
 			}
 		}


### PR DESCRIPTION
In some cases, docker service does not start, because torcx is not able to unpack tarball like the following error:

```
failed to unpack: unpacking \"/usr/share/torcx/store/docker:com.coreos.cl.torcx.tgz\":
error extracting tar: operation not supported" image=docker reference=com.coreos.cl
```

This means `Setxattr()` returns EOPNOTSUPP, especially when SELinux is disabled on the host.
To work around the issue, let's ignore EOPNOTSUPP.

This PR is for Edge.