### PR TITLE
internal/torcx: Mount tmpfs filesystem with fixed size

### DIFF
--- a/internal/torcx/perform.go
+++ b/internal/torcx/perform.go
@@ -284,7 +284,7 @@ func setupPaths(applyCfg *ApplyConfig) error {
 
 	// Now, mount a tmpfs directory to the unpack directory.
 	// We need to do this because "/run" is typically marked "noexec".
-	if err := unix.Mount("none", applyCfg.RunUnpackDir(), "tmpfs", 0, ""); err != nil {
+	if err := unix.Mount("none", applyCfg.RunUnpackDir(), "tmpfs", 0, "size=450M"); err != nil {
 		return errors.Wrap(err, "failed to mount unpack dir")
 	}
 


### PR DESCRIPTION
The tmpfs filesystem used to be mounted with the defaults of using
50% of the system RAM as size. For machines with 512 MB RAM this
was 256 MB but now the Docker image grew and requires 299 MB and
unpacking fails.
Set a hardcoded size of 450 MB which works as minimum size to ensure
the tmpfs is large enough for unpacking but also as maximum size
meaning that using a larger image would fail. We could also choose
an arbitrary high size like size=1T for 1 TB but on the other hand
it wouldn't be nice if torcx consumes more than 450 MB on a small
instance with 1 GB RAM and we should notice this during testing and
find ways to reduce the torcx image size.


# How to use

Build a Flatcar image with this torcx version and run the kola test suite.

# Testing done

Ran the kola test suite for qemu/VMware