### PR TITLE
Makefile: Do not set user ID for container processes when using Podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,8 @@ IMAGE ?= $(REGISTRY)/$(BIN)$(IMARCH)
 
 BUILD_IMAGE ?= golang:1.15
 
+SET_USER=$(shell (docker --version | grep -q podman) || echo "-u $(shell id -u):$(shell id -g)")
+
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-container' rule.
 # If you want to build AND push all containers, see the 'all-push' rule.
@@ -79,8 +81,7 @@ build: bin/$(ARCH)/$(BIN)
 bin/$(ARCH)/$(BIN): build-dirs
 	@echo "building: $@"
 	@docker run                                                            \
-	    -ti                                                                \
-	    -u $$(id -u):$$(id -g)                                             \
+	    -ti $(SET_USER)                                                    \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/$(ARCH):/go/bin                                     \
@@ -115,8 +116,7 @@ version:
 
 test: build-dirs
 	@docker run                                                            \
-	    -ti                                                                \
-	    -u $$(id -u):$$(id -g)                                             \
+	    -ti $(SET_USER)                                                    \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/$(ARCH):/go/bin                                     \


### PR DESCRIPTION
With Podman the container root user is mapped to the user that starts
the container. This means the file permissions are already correct and
using a different user inside the container results in missing file
permissions.
Only set the user ID for Docker, not when Podman is used through a
"docker" wrapper script.


# How to use/testing done

`make`/`make test`

