### PR TITLE
torcx/perform: make it works with enforced SELinux

### DIFF
--- a/internal/torcx/perform.go
+++ b/internal/torcx/perform.go
@@ -328,7 +328,6 @@ func unpackTgz(applyCfg *ApplyConfig, tgzPath, imageName string) (string, error)
 
 	tr := tar.NewReader(gr)
 	untarCfg := pkgtar.ExtractCfg{}.Default()
-	untarCfg.XattrPrivileged = true
 	err = pkgtar.ChrootUntar(tr, topDir, untarCfg)
 	if err != nil {
 		return "", errors.Wrapf(err, "unpacking %q", tgzPath)

--- a/internal/torcx/perform.go
+++ b/internal/torcx/perform.go
@@ -244,13 +244,6 @@ func SealSystemState(applyCfg *ApplyConfig) error {
 		}
 	}
 
-	// Remount the unpackdir RO
-	if err := unix.Mount(applyCfg.RunUnpackDir(), applyCfg.RunUnpackDir(),
-		"", unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {
-
-		return errors.Wrap(err, "failed to remount read-only")
-	}
-
 	logrus.WithFields(logrus.Fields{
 		"path":    SealPath,
 		"content": content,


### PR DESCRIPTION
* [`Revert "internal: enable XattrPrivileged for untar to fix selinux issue`](https://github.com/flatcar-linux/torcx/commit/90b4918ce2425e5a31e5274cb969643b4a24101c)

This is required in order to avoid this denial:
```
Nov 15 09:45:43 localhost audit[688]: AVC avc: denied { associate } for pid=688 comm="torcx-generator" name="docker" dev="tmpfs" ino=2 scontext=system_u:object_r:unlabeled_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=0
```

After some investigations, we found the following reason: during the unpacking of the Torcx image with `XattrPrivileged` option, we try to set the xattr on the extracted files. If the `security.selinux` attribute is not set, it defaults to `unlabeled_t` which is not able to be associated with the targeted filesystem. This denial prevents Torcx to be ran with SELinux enforced mode -> no docker/containerd.

Which leads to the second commit.

* [`perform: do not remount in RO`](https://github.com/flatcar-linux/torcx/commit/9cfcca57b24d2be651dab36ed63cf479b8b83df3)

Once the image unpacked, the Torcx image is sealed (means remounted as read-only) - the Torcx image is fully unlabeled, so we need to define filecontexts for the most important files in it. Since Torcx runs as a systemd-generator, file contexts are not available during the unpacking so we need to wait for `systemd-tmpfile` to relabel `/run` to get the proper labels.
The remount in ro can be performed right after.  