### PR TITLE
Update GitHub Actions for default branch rename: flatcar-master → main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ flatcar-master ]
+    branches: [ main ]
   pull_request:
-    branches: [ flatcar-master ]
+    branches: [ main ]
 
 jobs:
 

--- a/internal/torcx/profile_test.go
+++ b/internal/torcx/profile_test.go
@@ -35,7 +35,7 @@ var inManifest = ProfileManifestV0JSON{
 
 func TestGetProfileV0(t *testing.T) {
 	// Schema of profile v0 is described in
-	// https://github.com/flatcar/torcx/blob/master/Documentation/schemas/profile-manifest-v0.md
+	// https://github.com/flatcar/torcx/blob/main/Documentation/schemas/profile-manifest-v0.md
 	profilePath := "../../fixtures/test-get-profile-v0.json"
 
 	if _, err := os.Stat(profilePath); err != nil {


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions workflow configuration to prepare for renaming the default branch from `flatcar-master` to `main`.

## Changes Made
- **`.github/workflows/go.yml`**: Updated branch triggers from `flatcar-master` to `main`
  - Push events now trigger on `main` branch
  - Pull request events now target `main` branch
Part of https://github.com/flatcar/Flatcar/issues/1714